### PR TITLE
Increase histogram size to avoid out of bounds access

### DIFF
--- a/oroch/integer_codec.h
+++ b/oroch/integer_codec.h
@@ -160,7 +160,7 @@ private:
 	original_t maxvalue_ = std::numeric_limits<original_t>::min();
 
 	// The log2 histogram of values.
-	std::array<size_t, nbits> histogram_ = {};
+	std::array<size_t, nbits + 1> histogram_ = {};
 };
 
 } // namespace oroch::detail


### PR DESCRIPTION
When compiling with `-fsanitize=address` or `-fstack-protector-strong`, `build_histogram(Iter, Iter const)` crashes the program by writing one element past the end of `histogram_`.
